### PR TITLE
Hotfix: metadata

### DIFF
--- a/blackcortex_cli/utils/metadata.py
+++ b/blackcortex_cli/utils/metadata.py
@@ -1,29 +1,48 @@
 # blackcortex_cli/utils/metadata.py
 
 """
-Utilities for reading project metadata from pyproject.toml.
+Utilities for reading project metadata, primarily from installed package metadata,
+with a fallback to pyproject.toml during development.
 """
 
 import tomllib
+from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
+
+toml_load = tomllib.load
 
 
 def read_metadata() -> dict:
     """
-    Load the [project] metadata section from pyproject.toml.
+    Load the project metadata, preferring installed package metadata over pyproject.toml.
 
     Returns:
         A dictionary containing the project's metadata.
     """
-    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
-    with pyproject_path.open("rb") as f:
-        data = tomllib.load(f)
-    return data.get("project", {})
+    try:
+        # Try to get metadata from the installed package
+        package_metadata = metadata("blackcortex-gpt-cli")
+        return {
+            "name": package_metadata["Name"],
+            "version": package_metadata["Version"],
+            # Add other metadata fields as needed
+        }
+    except PackageNotFoundError:
+        # Fallback to reading pyproject.toml during development
+        if toml_load is None:
+            return {}
+        try:
+            pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+            with pyproject_path.open("rb") as f:
+                data = toml_load(f)
+            return data.get("project", {})
+        except (FileNotFoundError, ValueError):
+            return {}
 
 
 def read_version() -> str:
     """
-    Return the project's version string from pyproject.toml.
+    Return the project's version string, preferring installed package metadata.
 
     Returns:
         The version as a string, or "0.0.0" if not found.
@@ -33,7 +52,7 @@ def read_version() -> str:
 
 def read_name() -> str:
     """
-    Return the project's name from pyproject.toml.
+    Return the project's name, preferring installed package metadata.
 
     Returns:
         The name as a string, or "unknown" if not found.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blackcortex-gpt-cli"
-version = "1.3.0"
+version = "1.3.1"
 description = "Terminal-based GPT CLI with memory, markdown, and stream support"
 keywords = ["gpt", "cli", "terminal", "openai"]
 readme = "README.md"

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -1,74 +1,109 @@
 import io
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
+
 import pytest
-from blackcortex_cli.utils.metadata import read_metadata, read_version, read_name
+
+from blackcortex_cli.utils.metadata import read_metadata, read_name, read_version
 
 
 # Tests for read_metadata
-def test_read_metadata_normal():
-    """Test read_metadata with a normal [project] section."""
-    toml_content = b'[project]\nname = "myproject"\nversion = "1.0.0"'
-    with patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)):
-        metadata = read_metadata()
-        assert metadata == {"name": "myproject", "version": "1.0.0"}
+def test_read_metadata_from_package_metadata():
+    """Test read_metadata using importlib.metadata."""
+    mock_metadata = {"Name": "blackcortex-gpt-cli", "Version": "1.2.2"}
+    with patch("blackcortex_cli.utils.metadata.metadata", return_value=mock_metadata):
+        result = read_metadata()
+        assert result == {"name": "blackcortex-gpt-cli", "version": "1.2.2"}
 
 
-def test_read_metadata_missing_keys():
-    """Test read_metadata when some keys are missing in [project]."""
-    toml_content = b'[project]\nname = "myproject"'
-    with patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)):
-        metadata = read_metadata()
-        assert metadata == {"name": "myproject"}
+def test_read_metadata_from_pyproject_toml():
+    """Test read_metadata fallback to pyproject.toml."""
+    toml_content = b'[project]\nname = "blackcortex-gpt-cli"\nversion = "1.2.2"'
+    with (
+        patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)),
+        patch("blackcortex_cli.utils.metadata.metadata", side_effect=PackageNotFoundError),
+    ):
+        result = read_metadata()
+        assert result == {"name": "blackcortex-gpt-cli", "version": "1.2.2"}
 
 
-def test_read_metadata_no_project():
-    """Test read_metadata when [project] section is missing."""
+def test_read_metadata_missing_project_section():
+    """Test read_metadata when pyproject.toml has no [project] section."""
     toml_content = b'[tool]\nsomething = "else"'
-    with patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)):
-        metadata = read_metadata()
-        assert metadata == {}
+    with (
+        patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)),
+        patch("blackcortex_cli.utils.metadata.metadata", side_effect=PackageNotFoundError),
+    ):
+        result = read_metadata()
+        assert result == {}
 
 
 def test_read_metadata_file_not_found():
-    """Test read_metadata when pyproject.toml does not exist."""
-    with patch("pathlib.Path.open", side_effect=FileNotFoundError):
-        with pytest.raises(FileNotFoundError):
-            read_metadata()
+    """Test read_metadata when pyproject.toml is missing."""
+    with (
+        patch("pathlib.Path.open", side_effect=FileNotFoundError),
+        patch("blackcortex_cli.utils.metadata.metadata", side_effect=PackageNotFoundError),
+    ):
+        result = read_metadata()
+        assert result == {}
+
+
+def test_read_metadata_invalid_toml():
+    """Test read_metadata when pyproject.toml is invalid."""
+    toml_content = b"invalid = toml\nsyntax"
+    with (
+        patch("pathlib.Path.open", return_value=io.BytesIO(toml_content)),
+        patch("blackcortex_cli.utils.metadata.metadata", side_effect=PackageNotFoundError),
+    ):
+        result = read_metadata()
+        assert result == {}
 
 
 # Tests for read_version
-def test_read_version_normal():
-    """Test read_version when version is present."""
-    with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={"version": "1.0.0"}):
-        assert read_version() == "1.0.0"
+def test_read_version_from_metadata():
+    """Test read_version using package metadata."""
+    with patch(
+        "blackcortex_cli.utils.metadata.read_metadata",
+        return_value={"name": "blackcortex-gpt-cli", "version": "1.2.2"},
+    ):
+        result = read_version()
+        assert result == "1.2.2"
 
 
-def test_read_version_missing():
+def test_read_version_missing_version():
     """Test read_version when version is missing."""
     with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={"name": "myproject"}):
-        assert read_version() == "0.0.0"
+        result = read_version()
+        assert result == "0.0.0"
 
 
-def test_read_version_no_project():
-    """Test read_version when [project] section is missing."""
+def test_read_version_empty_metadata():
+    """Test read_version when metadata is empty."""
     with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={}):
-        assert read_version() == "0.0.0"
+        result = read_version()
+        assert result == "0.0.0"
 
 
 # Tests for read_name
-def test_read_name_normal():
-    """Test read_name when name is present."""
-    with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={"name": "myproject"}):
-        assert read_name() == "myproject"
+def test_read_name_from_metadata():
+    """Test read_name using package metadata."""
+    with patch(
+        "blackcortex_cli.utils.metadata.read_metadata",
+        return_value={"name": "blackcortex-gpt-cli", "version": "1.2.2"},
+    ):
+        result = read_name()
+        assert result == "blackcortex-gpt-cli"
 
 
-def test_read_name_missing():
+def test_read_name_missing_name():
     """Test read_name when name is missing."""
-    with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={"version": "1.0.0"}):
-        assert read_name() == "unknown"
+    with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={"version": "1.2.2"}):
+        result = read_name()
+        assert result == "unknown"
 
 
-def test_read_name_no_project():
-    """Test read_name when [project] section is missing."""
+def test_read_name_empty_metadata():
+    """Test read_name when metadata is empty."""
     with patch("blackcortex_cli.utils.metadata.read_metadata", return_value={}):
-        assert read_name() == "unknown"
+        result = read_name()
+        assert result == "unknown"


### PR DESCRIPTION
This pull request updates the metadata handling in the `blackcortex-gpt-cli` package to prioritize installed package metadata over `pyproject.toml` and improves the test suite to reflect these changes. It also includes a version bump in the `pyproject.toml` file.

### Metadata Handling Enhancements:
* Updated `read_metadata` and related functions to first attempt retrieving metadata from the installed package using `importlib.metadata`, with a fallback to `pyproject.toml` for development scenarios. (`blackcortex_cli/utils/metadata.py`, [blackcortex_cli/utils/metadata.pyL4-R45](diffhunk://#diff-8cc027ed3afc3599015d6d50974768a518ad8865a5e16274675d6241b54addf4L4-R45))
* Modified `read_name` and `read_version` functions to reflect the same preference for installed package metadata. (`blackcortex_cli/utils/metadata.py`, [blackcortex_cli/utils/metadata.pyL36-R55](diffhunk://#diff-8cc027ed3afc3599015d6d50974768a518ad8865a5e16274675d6241b54addf4L36-R55))

### Testing Improvements:
* Added new test cases to validate metadata retrieval from both installed package metadata and `pyproject.toml`, including edge cases like missing or invalid `pyproject.toml`. (`tests/utils/test_metadata.py`, [tests/utils/test_metadata.pyR2-R109](diffhunk://#diff-942bac4b41e74f68a6e8f7bbcb62f68d0c6540f1d3369d1adaecd94934ca7e86R2-R109))
* Replaced outdated tests with updated versions to align with the new metadata handling logic. (`tests/utils/test_metadata.py`, [tests/utils/test_metadata.pyR2-R109](diffhunk://#diff-942bac4b41e74f68a6e8f7bbcb62f68d0c6540f1d3369d1adaecd94934ca7e86R2-R109))

### Version Update:
* Incremented the package version from `1.3.0` to `1.3.1` in `pyproject.toml` to reflect the changes introduced. (`pyproject.toml`, [pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3))